### PR TITLE
Establish the Blast V2 architecture foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,16 @@ The main data flow is:
 - `packages/blast-utils/` — shared utilities, including Node runtime helpers.
 - `docs/` — product and application-flow documentation.
 
+V2 is being developed alongside the prototype:
+
+- `packages/blast-protocol/` — transport-independent V2 messages and schemas.
+- `packages/blast-extension-host/` — V2 extension lifecycle boundary.
+- `docs/v2/` — accepted product direction, architecture, decisions, and migration plan.
+
+V2 packages must not import from the prototype packages' `src/` directories.
+Keep `@blastlauncher/protocol` independent of React, Electron, Node.js runtime
+APIs, and concrete transports.
+
 ## Toolchain
 
 - Use Node.js 24.20.0 or newer. `.nvmrc` pins the baseline CI/runtime to
@@ -126,20 +136,20 @@ ignore files.
 - Read the package README and relevant files in `docs/` before changing a
   package's public behavior.
 
-## Modernization direction
+## V2 direction
 
-Before upgrading the dependency graph, agree on the revived product goal and
-compatibility policy. A likely direction is a modern, cross-platform,
-extensible desktop launcher with a maintained plugin SDK, secure extension
-runtime, and current Node/React/Electron dependencies.
+Blast V2 is a clean-slate implementation within the existing repository. Its
+goal is a small, open runtime for a measured subset of Raycast-compatible
+extensions. The launcher is the first client, not part of the extension runtime
+contract. Read `docs/v2/` before changing V2 public behavior.
 
-Recommended modernization order:
+Recommended implementation order:
 
-1. Record the current behavior and package contracts.
-2. Repair CI, test discovery, and reproducible toolchain selection.
-3. Upgrade TypeScript, React, Electron, and build tooling in isolated groups.
-4. Harden extension execution, permissions, IPC, and runtime installation.
-5. Improve the launcher UX and extension authoring/publishing workflow.
+1. Establish the versioned, transport-neutral protocol and lifecycle boundary.
+2. Measure API usage in the public extension corpus.
+3. Complete one isolated extension-to-client vertical slice.
+4. Expand compatibility in measured order with deterministic fixtures.
+5. Cut the desktop client over only after the V2 path is proven.
 
-Do not begin with a broad package upgrade that silently changes the extension
-contract.
+Do not couple V2 to V1 internals for short-term reuse, and do not remove V1 until
+the migration criteria in `docs/v2/migration.md` are satisfied.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
-# Blast Launcher (aka C8763)
+# Blast Launcher
+
+## V2 direction
+
+> **Project status:** Blast is being redesigned as a small, open runtime for
+> Raycast-compatible extensions. The current application remains an experimental
+> prototype while the V2 foundation is developed alongside it.
+
+The goal is to keep useful open-source launcher extensions running beyond the
+lifetime of any single client or maintainer. Compatibility will be measured
+against real extensions rather than claimed as complete feature parity.
+
+- [V2 product direction](./docs/v2/README.md)
+- [V2 architecture](./docs/v2/architecture.md)
+- [Migration plan](./docs/v2/migration.md)
+- [Architecture decisions](./docs/v2/decisions/)
+
+## V1 prototype
+
+The remainder of this README documents the original prototype while V2 is
+developed alongside it.
 
 **Update**: I wrote [an introduction post](https://yukai.dev/blog/2023/08/22/launching-blast-from-poc-to-01) for Blast Launcher.
 
@@ -18,32 +38,11 @@ can only be used in Raycast. So here's where this project comes in.
 
 Blast provides an open-source React renderer to render these Raycast extensions.
 
-<!--toc:start-->
-
-- [Blast Launcher (aka C8763)](#blast-launcher-aka-c8763)
-  - [Demo](#demo)
-  - [Architecture](#architecture)
-  - [Basic usage](#basic-usage)
-    - [Install](#install)
-    - [Usage](#usage)
-  - [Development](#development)
-  - [Debugging](#debugging)
-    - [See runtime logs](#see-runtime-logs)
-    - [Debugging runtime with React DevTools](#debugging-runtime-with-react-devtools)
-  - [Inspiration and related projects](#inspiration-and-related-projects)
-  - [FAQs](#faqs)
-    - [Why naming blast?](#why-naming-blast)
-    - [Why C8763?](#why-c8763)
-  - [Links](#links)
-  - [License](#license)
-
-<!--toc:end-->
-
 ## Demo
 
 ![demo_todo](./docs/media/demo_todo.gif)
 
-## Architecture
+## Prototype architecture
 
 Blast uses the following components:
 

--- a/docs/v2/README.md
+++ b/docs/v2/README.md
@@ -1,0 +1,81 @@
+# Blast V2 product direction
+
+## Mission
+
+Blast keeps open-source launcher extensions useful by providing a small, open,
+portable host for Raycast-compatible commands.
+
+The launcher is the first client of the runtime, not the runtime itself. A
+future desktop, terminal, web, remote, or mobile client should be able to speak
+the same protocol without becoming part of the extension process.
+
+## Product promise
+
+Blast will:
+
+- run a useful, explicitly documented subset of existing Raycast extensions;
+- make compatibility measurable at the command and API level;
+- isolate extension failures from the launcher and other extensions;
+- broker privileged host operations through declared capabilities;
+- keep extension installation, diagnostics, patches, and upgrades inspectable;
+- provide an open protocol that does not require the Electron client.
+
+Blast will not initially attempt to reproduce every built-in Raycast feature.
+AI chat, cloud sync, teams, notes, window management, and an advanced extension
+store are not requirements for the first V2 release. They can be clients,
+capability providers, or extensions later.
+
+## Principles
+
+### Compatibility is evidence
+
+Compatibility is a report, not a binary marketing label. A scanner and test
+harness will measure which APIs each extension uses and whether its commands
+start, render, receive events, and call host capabilities successfully.
+
+Unsupported APIs must fail with structured diagnostics. Extension-specific
+workarounds should be reviewable compatibility patches rather than invisible
+branches in the host.
+
+### Keep the core narrow
+
+The core owns extension discovery, lifecycle, protocol sessions, permissions,
+and capability routing. Search, user interface, stores, and operating-system
+integrations live outside the core.
+
+### Preserve user choice
+
+Extension source, manifests, preferences, compatibility patches, and diagnostic
+output should remain inspectable and portable. No essential local workflow may
+depend on a proprietary Blast service.
+
+### Agents use public control surfaces
+
+An agent should use the same versioned CLI and protocol available to a person.
+Mutating operations must support preview, explicit authorization where needed,
+structured results, and rollback. Agent support does not grant extensions or
+agents ambient access to the desktop.
+
+## First compatibility target
+
+The first vertical slice will run a real extension command that:
+
+1. is discovered from its manifest;
+2. starts in a dedicated extension process;
+3. negotiates a protocol version with the host;
+4. renders a list and an action in the desktop client;
+5. sends the action event back to the extension;
+6. requests clipboard access through the capability broker;
+7. produces structured logs and survives an extension crash.
+
+After that slice works, an API-usage census of the public extension corpus will
+determine which compatibility APIs are implemented next.
+
+## Success measures
+
+- cold and warm command-start latency are recorded on reference hardware;
+- idle memory is measured separately for the client, core, and extension hosts;
+- the compatibility report names tested extensions, commands, and API coverage;
+- an extension crash does not terminate the core or desktop client;
+- no extension receives an undeclared privileged capability;
+- at least one extension can render through a second client or test renderer.

--- a/docs/v2/architecture.md
+++ b/docs/v2/architecture.md
@@ -1,0 +1,129 @@
+# Blast V2 architecture
+
+## System shape
+
+```mermaid
+flowchart LR
+    E[Raycast extension] --> C[Raycast compatibility adapter]
+    N[Blast-native extension] --> S[Blast SDK]
+    C --> H[Extension host]
+    S --> H
+    H <--> P[Blast protocol]
+    P <--> D[Core daemon]
+    D <--> U[Desktop client]
+    D <--> T[CLI or test client]
+    D <--> R[Future remote client]
+    D <--> B[Capability providers]
+```
+
+The initial implementation may run the core daemon as a child of the desktop
+client. The protocol and lifecycle must not rely on that ownership arrangement.
+
+## Responsibilities
+
+### Protocol
+
+`@blastlauncher/protocol` defines versioned wire messages and semantic data
+shared across processes. It has no dependency on React, Electron, Node.js, or a
+specific transport.
+
+The protocol will cover:
+
+- handshake and version negotiation;
+- extension and command lifecycle;
+- semantic scene mutations and user events;
+- capability requests, results, and cancellation;
+- structured diagnostics and shutdown.
+
+WebSocket, local sockets, named pipes, standard I/O, and in-memory test channels
+are transports for this protocol. None is the canonical architecture.
+
+### Extension host
+
+`@blastlauncher/extension-host` supervises extension sessions. It owns start,
+stop, cancellation, crash reporting, and resource limits. Each untrusted
+extension runs outside the core process.
+
+Node.js is the default compatibility runtime because existing extensions depend
+on Node.js behavior and packages. Other runtimes may be added for Blast-native
+extensions after compatibility is measured.
+
+### Compatibility adapter
+
+The Raycast adapter implements the supported `@raycast/api` surface on top of
+the Blast protocol and capability requests. It does not define the internal
+protocol. Unsupported behavior returns a structured compatibility error.
+
+### Core daemon
+
+The core maintains the extension registry, active sessions, capability policy,
+and connected clients. It does not render React components and does not perform
+desktop operations on behalf of an extension without a capability provider.
+
+### Clients
+
+Clients discover commands, render semantic scenes, collect user input, and send
+events. The Electron desktop application is the reference client during the V2
+migration, but client-specific types must not enter the protocol package.
+
+### Capability providers
+
+Providers implement host operations such as clipboard access, opening URLs,
+secure storage, notifications, OAuth, and selected filesystem access. Requests
+include the extension identity, capability name, operation, and arguments so the
+core can enforce policy and record an audit event.
+
+## Dependency rules
+
+```text
+compat-raycast ----\
+blast-api ----------> extension-host ---> protocol <--- desktop client
+                                         ^
+capability providers --------------------+
+```
+
+1. `protocol` has no workspace dependencies and no platform dependencies.
+2. Clients and adapters depend on `protocol`; `protocol` never depends on them.
+3. Extension code cannot import core or client internals.
+4. Privileged operations cross the capability boundary.
+5. Transport implementations carry protocol messages without changing their
+   meaning.
+6. Package consumers import public exports, never another package's `src/`
+   directory.
+
+## Session model
+
+Every connection begins with a `hello` message listing the peer role and
+supported protocol versions. The receiver selects a version in `ready` or ends
+the session with a structured error. All later messages carry that version, a
+message identifier, a type, and a payload.
+
+The initial protocol scaffold intentionally defines only the common envelope
+and handshake. Scene and capability messages will be added with their vertical
+slices, preventing speculative wire contracts from becoming compatibility
+obligations.
+
+## Security model
+
+Blast distinguishes two trust modes:
+
+- **distributed:** isolated execution and only declared, brokered capabilities;
+- **personal:** broader access may be granted explicitly for locally authored
+  extensions and scripts.
+
+The trust mode changes policy, not protocol shape. Remote transports require
+authentication and encryption before they may carry privileged requests.
+
+## Source layout during migration
+
+```text
+packages/blast-protocol/        V2 wire contract
+packages/blast-extension-host/  V2 lifecycle boundary
+packages/blast-api/             V1 compatibility implementation
+packages/blast-runtime/         V1 runtime
+packages/blast-renderer/        V1 renderer
+apps/electron-client/           V1 reference client
+```
+
+New V2 packages coexist with the prototype until an end-to-end slice replaces
+the useful path. Existing package names are not repurposed silently.

--- a/docs/v2/decisions/0001-rewrite-in-place.md
+++ b/docs/v2/decisions/0001-rewrite-in-place.md
@@ -1,0 +1,28 @@
+# ADR 0001: Rewrite V2 in the existing repository
+
+- Status: accepted
+- Date: 2026-08-27
+
+## Context
+
+The 2023 prototype proved that Raycast-style React extensions could be executed
+by an open host and rendered by a separate Electron client. Its API, renderer,
+runtime, transport, and privileged operations are tightly coupled, so preserving
+the implementation would constrain the new architecture.
+
+The product mission remains the same: provide an open home for useful launcher
+extensions. Repository history, attribution, issues, and the modernized
+toolchain therefore remain relevant.
+
+## Decision
+
+Build V2 as new packages and vertical slices in the existing Git history. Do
+not create an orphan branch. Keep the prototype runnable until V2 replaces its
+useful path, then remove legacy code in an explicit commit.
+
+## Consequences
+
+- V2 may replace nearly all application code without hiding how it evolved.
+- Modern toolchain and CI work is reused.
+- V1 and V2 coexist temporarily, increasing workspace size.
+- New packages must not depend on V1 internals merely to accelerate migration.

--- a/docs/v2/decisions/0002-protocol-first.md
+++ b/docs/v2/decisions/0002-protocol-first.md
@@ -1,0 +1,27 @@
+# ADR 0002: Make the extension protocol the stable boundary
+
+- Status: accepted
+- Date: 2026-08-27
+
+## Context
+
+The prototype couples a custom React renderer directly to an RPC WebSocket and
+emits a complete serialized tree. API components also perform host operations
+directly. These choices make isolation, alternate clients, remote execution,
+and permission enforcement difficult.
+
+## Decision
+
+Define a small, versioned protocol independent of React, Electron, Node.js, and
+transport. Raycast compatibility, extension execution, clients, and capability
+providers all adapt to that protocol.
+
+Start with the message envelope and handshake. Add scene and capability messages
+only alongside tested vertical slices.
+
+## Consequences
+
+- WebSocket remains available but is no longer a fixed system boundary.
+- Clients can be replaced without changing extension APIs.
+- Protocol changes require compatibility and versioning discipline.
+- React reconciliation becomes an adapter concern rather than the wire format.

--- a/docs/v2/decisions/0003-node-compatibility-runtime.md
+++ b/docs/v2/decisions/0003-node-compatibility-runtime.md
@@ -1,0 +1,23 @@
+# ADR 0003: Use Node.js as the initial compatibility runtime
+
+- Status: accepted
+- Date: 2026-08-27
+
+## Context
+
+Existing Raycast extensions rely on Node.js packages, resolution behavior, and
+built-in modules. Selecting a different JavaScript runtime would add another
+source of incompatibility before Blast can measure its API coverage.
+
+## Decision
+
+Use the repository's pinned Node.js version for the first isolated extension
+host. Keep runtime launch behind an interface so Blast-native extensions may use
+other runtimes later.
+
+## Consequences
+
+- Early compatibility work has fewer variables.
+- Bun is not required for V2's first release.
+- Performance work begins with lifecycle, caching, isolation, and protocol
+  efficiency rather than runtime substitution.

--- a/docs/v2/migration.md
+++ b/docs/v2/migration.md
@@ -1,0 +1,71 @@
+# Blast V2 migration plan
+
+Blast V2 is a clean-slate implementation inside the existing repository. The
+prototype stays runnable while the new boundaries are proved. Removal happens
+only after a replacement path exists.
+
+## Phase 0: baseline
+
+- Merge and preserve the reproducible Node.js, pnpm, CI, and packaging setup.
+- Record the V1 package graph and known architectural coupling.
+- Keep V1 builds and tests green while V2 is introduced.
+
+Exit condition: a clean checkout uses the pinned toolchain and passes the
+existing checks.
+
+## Phase 1: protocol and lifecycle foundation
+
+- Add the transport-neutral protocol package.
+- Add the extension-host lifecycle boundary.
+- Implement handshake negotiation and an in-memory test connection.
+- Define structured error and shutdown behavior.
+
+Exit condition: a test process can negotiate, exchange a message, cancel, and
+shut down without Electron or WebSocket.
+
+## Phase 2: compatibility census
+
+- Build a static scanner for extension manifests and `@raycast/api` imports.
+- Select a varied fixture set of real extensions.
+- Publish a generated support matrix by API, command, platform, and failure
+  reason.
+
+Exit condition: the first supported API subset is justified by corpus usage and
+named fixtures.
+
+## Phase 3: first vertical slice
+
+- Start one extension command in an isolated Node.js process.
+- Translate `List`, `List.Item`, `ActionPanel`, and one action.
+- Render the semantic operations in the desktop client.
+- Broker clipboard access and report a denied request.
+- Surface crashes and logs without terminating the client or core.
+
+Exit condition: the scenario in the V2 product document passes as an automated
+integration test.
+
+## Phase 4: useful compatibility subset
+
+- Expand components and capabilities in census order.
+- Add preferences, local storage, detail, form, grid, notifications, URL
+  opening, OAuth, and secure storage as justified by fixtures.
+- Introduce reviewable compatibility patches for abandoned extensions.
+
+Exit condition: Blast publishes an evidence-backed compatibility report for a
+representative extension set.
+
+## Phase 5: cutover
+
+- Point the desktop client at the V2 core and extension host.
+- Mark V1 packages as legacy and freeze their public behavior.
+- Remove V1 only in a dedicated, reviewable change after feature and migration
+  criteria are met.
+
+Exit condition: normal development and packaging no longer depend on V1.
+
+## Deferred work
+
+Remote execution, mobile clients, Quickshell integration, an agent control
+plane, and alternative JavaScript runtimes remain valid directions. V2 keeps
+their architectural seams open, but none is allowed to delay the first useful
+compatibility release.

--- a/packages/blast-extension-host/README.md
+++ b/packages/blast-extension-host/README.md
@@ -1,0 +1,7 @@
+# `@blastlauncher/extension-host`
+
+Lifecycle boundary for Blast V2 extension processes.
+
+This package defines extension identities, protocol connections, and process
+launch/stop behavior without selecting a transport or JavaScript runtime. The
+first concrete launcher will use isolated Node.js processes.

--- a/packages/blast-extension-host/package.json
+++ b/packages/blast-extension-host/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@blastlauncher/extension-host",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Extension lifecycle boundary for Blast V2",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm run build && node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@blastlauncher/protocol": "workspace:*"
+  }
+}

--- a/packages/blast-extension-host/src/index.ts
+++ b/packages/blast-extension-host/src/index.ts
@@ -1,0 +1,81 @@
+import type { ProtocolEnvelope } from "@blastlauncher/protocol";
+
+export interface ExtensionDescriptor {
+  readonly extensionId: string;
+  readonly commandName: string;
+  readonly entrypoint: string;
+  readonly rootDirectory: string;
+}
+
+export interface ProtocolConnection {
+  readonly messages: AsyncIterable<ProtocolEnvelope>;
+  send(message: ProtocolEnvelope): Promise<void>;
+  close(reason?: string): Promise<void>;
+}
+
+export interface ExtensionProcess {
+  readonly connection: ProtocolConnection;
+  readonly processId?: number;
+  stop(reason?: string): Promise<void>;
+}
+
+export interface ExtensionProcessLauncher {
+  launch(descriptor: ExtensionDescriptor, signal: AbortSignal): Promise<ExtensionProcess>;
+}
+
+export interface ExtensionSession {
+  readonly descriptor: ExtensionDescriptor;
+  readonly process: ExtensionProcess;
+}
+
+export class ExtensionHost {
+  readonly #launcher: ExtensionProcessLauncher;
+  readonly #sessions = new Map<string, ExtensionSession>();
+  readonly #startingSessions = new Set<string>();
+
+  constructor(launcher: ExtensionProcessLauncher) {
+    this.#launcher = launcher;
+  }
+
+  get activeSessions(): readonly ExtensionSession[] {
+    return [...this.#sessions.values()];
+  }
+
+  async start(descriptor: ExtensionDescriptor, signal: AbortSignal): Promise<ExtensionSession> {
+    const sessionKey = getSessionKey(descriptor);
+    if (this.#sessions.has(sessionKey) || this.#startingSessions.has(sessionKey)) {
+      throw new Error(`Extension session already exists: ${sessionKey}`);
+    }
+
+    this.#startingSessions.add(sessionKey);
+    try {
+      const process = await this.#launcher.launch(descriptor, signal);
+      const session = { descriptor, process };
+      this.#sessions.set(sessionKey, session);
+      return session;
+    } finally {
+      this.#startingSessions.delete(sessionKey);
+    }
+  }
+
+  async stop(extensionId: string, commandName: string, reason?: string): Promise<void> {
+    const sessionKey = getSessionKey({ extensionId, commandName });
+    const session = this.#sessions.get(sessionKey);
+    if (!session) {
+      return;
+    }
+
+    this.#sessions.delete(sessionKey);
+    await session.process.stop(reason);
+  }
+
+  async stopAll(reason?: string): Promise<void> {
+    const sessions = [...this.#sessions.values()];
+    this.#sessions.clear();
+    await Promise.all(sessions.map((session) => session.process.stop(reason)));
+  }
+}
+
+function getSessionKey(descriptor: Pick<ExtensionDescriptor, "extensionId" | "commandName">): string {
+  return JSON.stringify([descriptor.extensionId, descriptor.commandName]);
+}

--- a/packages/blast-extension-host/test/extension-host.test.mjs
+++ b/packages/blast-extension-host/test/extension-host.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ExtensionHost } from "../dist/index.js";
+
+const descriptor = {
+  extensionId: "example.extension",
+  commandName: "index",
+  entrypoint: "/tmp/example/index.js",
+  rootDirectory: "/tmp/example",
+};
+
+function createLauncher(stopped) {
+  return {
+    async launch() {
+      return {
+        connection: {
+          messages: {
+            async *[Symbol.asyncIterator]() {},
+          },
+          async send() {},
+          async close() {},
+        },
+        async stop(reason) {
+          stopped.push(reason);
+        },
+      };
+    },
+  };
+}
+
+test("tracks and stops an extension session", async () => {
+  const stopped = [];
+  const host = new ExtensionHost(createLauncher(stopped));
+
+  await host.start(descriptor, new AbortController().signal);
+  assert.equal(host.activeSessions.length, 1);
+
+  await host.stop(descriptor.extensionId, descriptor.commandName, "test complete");
+  assert.equal(host.activeSessions.length, 0);
+  assert.deepEqual(stopped, ["test complete"]);
+});
+
+test("rejects duplicate extension sessions", async () => {
+  const host = new ExtensionHost(createLauncher([]));
+  const signal = new AbortController().signal;
+
+  await host.start(descriptor, signal);
+  await assert.rejects(() => host.start(descriptor, signal), /session already exists/);
+});
+
+test("reserves a session while its process is starting", async () => {
+  let completeLaunch;
+  const launcher = createLauncher([]);
+  launcher.launch = () =>
+    new Promise((resolve) => {
+      completeLaunch = () => resolve(createLauncher([]).launch());
+    });
+
+  const host = new ExtensionHost(launcher);
+  const signal = new AbortController().signal;
+  const firstStart = host.start(descriptor, signal);
+
+  await assert.rejects(() => host.start(descriptor, signal), /session already exists/);
+  completeLaunch();
+  await firstStart;
+});

--- a/packages/blast-extension-host/tsconfig.json
+++ b/packages/blast-extension-host/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.v2.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/blast-protocol/README.md
+++ b/packages/blast-protocol/README.md
@@ -1,0 +1,8 @@
+# `@blastlauncher/protocol`
+
+Transport-independent wire primitives for Blast V2.
+
+This package must remain free of React, Electron, Node.js runtime APIs, and
+transport implementations. It initially defines only the common envelope and
+handshake. Messages for scenes and capabilities will be added with tested
+vertical slices.

--- a/packages/blast-protocol/package.json
+++ b/packages/blast-protocol/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@blastlauncher/protocol",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Transport-independent protocol primitives for Blast V2",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm run build && node --test test/*.test.mjs"
+  }
+}

--- a/packages/blast-protocol/src/index.ts
+++ b/packages/blast-protocol/src/index.ts
@@ -1,0 +1,53 @@
+export const BLAST_PROTOCOL_VERSION = 1 as const;
+
+export type ProtocolVersion = typeof BLAST_PROTOCOL_VERSION;
+
+export type PeerRole = "client" | "core" | "extension-host" | "capability-provider";
+
+export interface PeerImplementation {
+  readonly name: string;
+  readonly version: string;
+}
+
+export interface HelloPayload {
+  readonly role: PeerRole;
+  readonly protocolVersions: readonly number[];
+  readonly implementation: PeerImplementation;
+}
+
+export interface ReadyPayload {
+  readonly protocolVersion: number;
+  readonly sessionId: string;
+}
+
+export interface ProtocolErrorPayload {
+  readonly code: string;
+  readonly message: string;
+  readonly details?: unknown;
+}
+
+export interface ProtocolEnvelope<TType extends string = string, TPayload = unknown> {
+  readonly protocolVersion: number;
+  readonly id: string;
+  readonly type: TType;
+  readonly payload: TPayload;
+}
+
+export type HelloMessage = ProtocolEnvelope<"hello", HelloPayload>;
+export type ReadyMessage = ProtocolEnvelope<"ready", ReadyPayload>;
+export type ProtocolErrorMessage = ProtocolEnvelope<"error", ProtocolErrorPayload>;
+
+export type HandshakeMessage = HelloMessage | ReadyMessage | ProtocolErrorMessage;
+
+export function createMessage<TType extends string, TPayload>(
+  id: string,
+  type: TType,
+  payload: TPayload,
+): ProtocolEnvelope<TType, TPayload> {
+  return {
+    protocolVersion: BLAST_PROTOCOL_VERSION,
+    id,
+    type,
+    payload,
+  };
+}

--- a/packages/blast-protocol/test/protocol.test.mjs
+++ b/packages/blast-protocol/test/protocol.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BLAST_PROTOCOL_VERSION, createMessage } from "../dist/index.js";
+
+test("createMessage adds the current protocol version", () => {
+  const message = createMessage("message-1", "hello", {
+    role: "client",
+    protocolVersions: [BLAST_PROTOCOL_VERSION],
+    implementation: { name: "test-client", version: "0.0.0" },
+  });
+
+  assert.deepEqual(message, {
+    protocolVersion: 1,
+    id: "message-1",
+    type: "hello",
+    payload: {
+      role: "client",
+      protocolVersions: [1],
+      implementation: { name: "test-client", version: "0.0.0" },
+    },
+  });
+});

--- a/packages/blast-protocol/tsconfig.json
+++ b/packages/blast-protocol/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.v2.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,14 @@ importers:
         specifier: ^5.8.0
         version: 5.8.1(encoding@0.1.13)(supports-color@8.1.1)
 
+  packages/blast-extension-host:
+    dependencies:
+      '@blastlauncher/protocol':
+        specifier: workspace:*
+        version: link:../blast-protocol
+
+  packages/blast-protocol: {}
+
   packages/blast-renderer:
     dependencies:
       '@blastlauncher/utils':
@@ -1666,7 +1674,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true

--- a/tsconfig.v2.json
+++ b/tsconfig.v2.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "exactOptionalPropertyTypes": true,
+    "isolatedModules": true,
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "target": "ES2023",
+    "verbatimModuleSyntax": true
+  }
+}


### PR DESCRIPTION
## Summary

- document the V2 product direction, architecture, and migration phases
- record rewrite-in-place, protocol-first, and Node compatibility decisions
- add transport-neutral `@blastlauncher/protocol` scaffolding
- add a tested `@blastlauncher/extension-host` lifecycle boundary
- keep the V1 prototype runnable during migration

## Validation

- `pnpm run build`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run fmt:check`

Lint completes with the existing V1 warnings and no errors.