### PR TITLE
Add the V2 protocol transport boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ The main data flow is:
 V2 is being developed alongside the prototype:
 
 - `packages/blast-protocol/` — transport-independent V2 messages and schemas.
+- `packages/blast-transport/` — V2 connection contract and in-memory test transport.
 - `packages/blast-extension-host/` — V2 extension lifecycle boundary.
 - `docs/v2/` — accepted product direction, architecture, decisions, and migration plan.
 

--- a/docs/v2/architecture.md
+++ b/docs/v2/architecture.md
@@ -38,6 +38,10 @@ The protocol will cover:
 WebSocket, local sockets, named pipes, standard I/O, and in-memory test channels
 are transports for this protocol. None is the canonical architecture.
 
+`@blastlauncher/transport` defines the shared connection interface and provides
+the deterministic in-memory implementation used by protocol and lifecycle
+tests. Concrete operating-system and network transports remain separate.
+
 ### Extension host
 
 `@blastlauncher/extension-host` supervises extension sessions. It owns start,
@@ -77,9 +81,10 @@ core can enforce policy and record an audit event.
 
 ```text
 compat-raycast ----\
-blast-api ----------> extension-host ---> protocol <--- desktop client
-                                         ^
-capability providers --------------------+
+blast-api ----------> extension-host ---> transport ---> protocol
+                                           ^              ^
+desktop client ---------------------------+--------------+
+capability providers ---------------------+--------------+
 ```
 
 1. `protocol` has no workspace dependencies and no platform dependencies.
@@ -118,6 +123,7 @@ authentication and encryption before they may carry privileged requests.
 
 ```text
 packages/blast-protocol/        V2 wire contract
+packages/blast-transport/       V2 transport boundary and in-memory pair
 packages/blast-extension-host/  V2 lifecycle boundary
 packages/blast-api/             V1 compatibility implementation
 packages/blast-runtime/         V1 runtime

--- a/docs/v2/decisions/0004-react-reconciler-adapter.md
+++ b/docs/v2/decisions/0004-react-reconciler-adapter.md
@@ -1,0 +1,58 @@
+# ADR 0004: Isolate React reconciliation behind a scene adapter
+
+- Status: accepted
+- Date: 2026-08-27
+
+## Context
+
+Raycast extensions are React applications. Supporting their state, hooks,
+effects, context, and component lifecycle requires a React renderer rather than
+a one-time JSX parser.
+
+The V1 custom renderer combines several responsibilities. Its host context
+contains the WebSocket RPC server, API hooks register RPC methods directly, and
+every React commit serializes and emits the complete element tree. That makes
+React and WebSocket part of the system boundary and creates unnecessary work for
+small updates.
+
+`react-reconciler` is explicitly experimental and does not offer the stability
+guarantees of React DOM or React Native. Its host configuration can change even
+when the public React component model remains compatible.
+
+## Decision
+
+Rewrite the reconciler as `@blastlauncher/react-renderer` when the first scene
+vertical slice begins. It will be an adapter from React host operations to a
+transport-independent scene mutation sink.
+
+The renderer will:
+
+- assign stable opaque identifiers to semantic nodes;
+- collect insert, update, remove, and reorder operations during a commit;
+- publish one ordered transaction to a supplied sink after the commit;
+- provide a complete snapshot only for initial attachment and recovery;
+- serialize a documented property whitelist;
+- translate callbacks into opaque event identifiers owned by the extension
+  runtime;
+- pin compatible React and `react-reconciler` versions and run renderer
+  conformance fixtures against upgrades.
+
+The renderer will not:
+
+- open sockets or know which transport carries a transaction;
+- register RPC methods;
+- execute clipboard, filesystem, URL, OAuth, or other host capabilities;
+- define client widgets or styling;
+- become the canonical application state store.
+
+## Consequences
+
+- React remains the compatibility authoring model without becoming Blast's wire
+  protocol.
+- Small state changes produce bounded mutations instead of complete tree
+  replacement.
+- Non-React extensions and non-Electron clients can use the same scene protocol.
+- React reconciler upgrades remain a contained maintenance cost rather than a
+  system-wide migration.
+- Scene mutation types will be added to the protocol only with the first tested
+  list/action vertical slice.

--- a/docs/v2/migration.md
+++ b/docs/v2/migration.md
@@ -19,6 +19,8 @@ existing checks.
 - Add the extension-host lifecycle boundary.
 - Implement handshake negotiation and an in-memory test connection.
 - Define structured error and shutdown behavior.
+- Record the React reconciler as a scene adapter without implementing scene
+  messages ahead of the first vertical slice.
 
 Exit condition: a test process can negotiate, exchange a message, cancel, and
 shut down without Electron or WebSocket.

--- a/packages/blast-extension-host/src/index.ts
+++ b/packages/blast-extension-host/src/index.ts
@@ -1,4 +1,4 @@
-import type { ProtocolEnvelope } from "@blastlauncher/protocol";
+import type { ProtocolTransport } from "@blastlauncher/transport";
 
 export interface ExtensionDescriptor {
   readonly extensionId: string;
@@ -7,14 +7,8 @@ export interface ExtensionDescriptor {
   readonly rootDirectory: string;
 }
 
-export interface ProtocolConnection {
-  readonly messages: AsyncIterable<ProtocolEnvelope>;
-  send(message: ProtocolEnvelope): Promise<void>;
-  close(reason?: string): Promise<void>;
-}
-
 export interface ExtensionProcess {
-  readonly connection: ProtocolConnection;
+  readonly connection: ProtocolTransport;
   readonly processId?: number;
   stop(reason?: string): Promise<void>;
 }

--- a/packages/blast-protocol/README.md
+++ b/packages/blast-protocol/README.md
@@ -3,6 +3,6 @@
 Transport-independent wire primitives for Blast V2.
 
 This package must remain free of React, Electron, Node.js runtime APIs, and
-transport implementations. It initially defines only the common envelope and
-handshake. Messages for scenes and capabilities will be added with tested
-vertical slices.
+transport implementations. It initially defines only the common envelope,
+handshake types, and deterministic version negotiation. Messages for scenes and
+capabilities will be added with tested vertical slices.

--- a/packages/blast-protocol/src/index.ts
+++ b/packages/blast-protocol/src/index.ts
@@ -1,4 +1,5 @@
 export const BLAST_PROTOCOL_VERSION = 1 as const;
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly number[] = [BLAST_PROTOCOL_VERSION];
 
 export type ProtocolVersion = typeof BLAST_PROTOCOL_VERSION;
 
@@ -50,4 +51,15 @@ export function createMessage<TType extends string, TPayload>(
     type,
     payload,
   };
+}
+
+export function negotiateProtocolVersion(
+  localVersions: readonly number[],
+  remoteVersions: readonly number[],
+): number | undefined {
+  const remoteVersionSet = new Set(remoteVersions);
+
+  return [...new Set(localVersions)]
+    .filter((version) => Number.isSafeInteger(version) && version > 0 && remoteVersionSet.has(version))
+    .toSorted((left, right) => right - left)[0];
 }

--- a/packages/blast-protocol/test/protocol.test.mjs
+++ b/packages/blast-protocol/test/protocol.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { BLAST_PROTOCOL_VERSION, createMessage } from "../dist/index.js";
+import { BLAST_PROTOCOL_VERSION, createMessage, negotiateProtocolVersion } from "../dist/index.js";
 
 test("createMessage adds the current protocol version", () => {
   const message = createMessage("message-1", "hello", {
@@ -20,4 +20,9 @@ test("createMessage adds the current protocol version", () => {
       implementation: { name: "test-client", version: "0.0.0" },
     },
   });
+});
+
+test("negotiates the highest shared protocol version", () => {
+  assert.equal(negotiateProtocolVersion([1, 3, 2], [2, 1]), 2);
+  assert.equal(negotiateProtocolVersion([1], [2]), undefined);
 });

--- a/packages/blast-transport/README.md
+++ b/packages/blast-transport/README.md
@@ -1,0 +1,8 @@
+# `@blastlauncher/transport`
+
+Transport boundary for Blast V2 protocol messages.
+
+The package defines the connection contract used by hosts and clients. Its
+in-memory transport is the reference implementation for deterministic tests.
+Local sockets, standard I/O, MessagePort, and WebSocket adapters will implement
+the same interface in separate modules without changing protocol messages.

--- a/packages/blast-transport/package.json
+++ b/packages/blast-transport/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@blastlauncher/extension-host",
+  "name": "@blastlauncher/transport",
   "version": "0.0.0",
   "private": true,
-  "description": "Extension lifecycle boundary for Blast V2",
+  "description": "Transport abstractions and in-memory transport for Blast V2",
   "license": "MIT",
   "files": [
     "dist"
@@ -19,6 +19,6 @@
     "test": "pnpm run build && node --test test/*.test.mjs"
   },
   "dependencies": {
-    "@blastlauncher/transport": "workspace:*"
+    "@blastlauncher/protocol": "workspace:*"
   }
 }

--- a/packages/blast-transport/src/index.ts
+++ b/packages/blast-transport/src/index.ts
@@ -1,0 +1,116 @@
+import type { ProtocolEnvelope } from "@blastlauncher/protocol";
+
+export interface ProtocolTransport {
+  readonly messages: AsyncIterable<ProtocolEnvelope>;
+  send(message: ProtocolEnvelope): Promise<void>;
+  close(reason?: string): Promise<void>;
+}
+
+export type InMemoryTransportPair = readonly [ProtocolTransport, ProtocolTransport];
+
+export function createInMemoryTransportPair(): InMemoryTransportPair {
+  const leftInbox = new AsyncQueue<ProtocolEnvelope>();
+  const rightInbox = new AsyncQueue<ProtocolEnvelope>();
+  const state = new PairState(leftInbox, rightInbox);
+
+  return [new InMemoryTransport(leftInbox, rightInbox, state), new InMemoryTransport(rightInbox, leftInbox, state)];
+}
+
+class InMemoryTransport implements ProtocolTransport {
+  readonly messages: AsyncIterable<ProtocolEnvelope>;
+  readonly #outbox: AsyncQueue<ProtocolEnvelope>;
+  readonly #state: PairState;
+
+  constructor(inbox: AsyncQueue<ProtocolEnvelope>, outbox: AsyncQueue<ProtocolEnvelope>, state: PairState) {
+    this.messages = inbox;
+    this.#outbox = outbox;
+    this.#state = state;
+  }
+
+  async send(message: ProtocolEnvelope): Promise<void> {
+    if (this.#state.closed) {
+      throw new Error("Protocol transport is closed");
+    }
+
+    this.#outbox.enqueue(message);
+  }
+
+  async close(reason?: string): Promise<void> {
+    void reason;
+    this.#state.close();
+  }
+}
+
+class PairState {
+  #closed = false;
+  readonly #inboxes: readonly AsyncQueue<ProtocolEnvelope>[];
+
+  constructor(...inboxes: readonly AsyncQueue<ProtocolEnvelope>[]) {
+    this.#inboxes = inboxes;
+  }
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  close(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#closed = true;
+    for (const inbox of this.#inboxes) {
+      inbox.close();
+    }
+  }
+}
+
+class AsyncQueue<T> implements AsyncIterableIterator<T> {
+  readonly #values: T[] = [];
+  readonly #waiters: ((result: IteratorResult<T>) => void)[] = [];
+  #closed = false;
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<T> {
+    return this;
+  }
+
+  next(): Promise<IteratorResult<T>> {
+    const value = this.#values.shift();
+    if (value !== undefined) {
+      return Promise.resolve({ done: false, value });
+    }
+
+    if (this.#closed) {
+      return Promise.resolve({ done: true, value: undefined });
+    }
+
+    return new Promise((resolve) => {
+      this.#waiters.push(resolve);
+    });
+  }
+
+  enqueue(value: T): void {
+    if (this.#closed) {
+      throw new Error("Cannot enqueue on a closed transport");
+    }
+
+    const waiter = this.#waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value });
+      return;
+    }
+
+    this.#values.push(value);
+  }
+
+  close(): void {
+    if (this.#closed) {
+      return;
+    }
+
+    this.#closed = true;
+    for (const waiter of this.#waiters.splice(0)) {
+      waiter({ done: true, value: undefined });
+    }
+  }
+}

--- a/packages/blast-transport/test/transport.test.mjs
+++ b/packages/blast-transport/test/transport.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMessage } from "@blastlauncher/protocol";
+
+import { createInMemoryTransportPair } from "../dist/index.js";
+
+test("delivers messages to the opposite endpoint in order", async () => {
+  const [left, right] = createInMemoryTransportPair();
+  const messages = right.messages[Symbol.asyncIterator]();
+  const first = createMessage("1", "test", { position: 1 });
+  const second = createMessage("2", "test", { position: 2 });
+
+  await left.send(first);
+  await left.send(second);
+
+  assert.deepEqual(await messages.next(), { done: false, value: first });
+  assert.deepEqual(await messages.next(), { done: false, value: second });
+});
+
+test("closing either endpoint closes the pair", async () => {
+  const [left, right] = createInMemoryTransportPair();
+  const leftMessages = left.messages[Symbol.asyncIterator]();
+  const rightMessages = right.messages[Symbol.asyncIterator]();
+
+  await left.close("test complete");
+
+  assert.deepEqual(await leftMessages.next(), { done: true, value: undefined });
+  assert.deepEqual(await rightMessages.next(), { done: true, value: undefined });
+  await assert.rejects(() => right.send(createMessage("1", "test", null)), /transport is closed/);
+});

--- a/packages/blast-transport/tsconfig.json
+++ b/packages/blast-transport/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.v2.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,9 +266,9 @@ importers:
 
   packages/blast-extension-host:
     dependencies:
-      '@blastlauncher/protocol':
+      '@blastlauncher/transport':
         specifier: workspace:*
-        version: link:../blast-protocol
+        version: link:../blast-transport
 
   packages/blast-protocol: {}
 
@@ -381,6 +381,12 @@ importers:
       rpc-websockets:
         specifier: ^10.0.1
         version: 10.0.1
+
+  packages/blast-transport:
+    dependencies:
+      '@blastlauncher/protocol':
+        specifier: workspace:*
+        version: link:../blast-protocol
 
   packages/blast-utils:
     dependencies:


### PR DESCRIPTION
## Summary

- record the V2 React reconciler as an isolated scene adapter
- add deterministic protocol-version negotiation
- introduce the shared `@blastlauncher/transport` contract
- provide an ordered, closeable in-memory transport pair for tests
- move the extension-host lifecycle boundary onto the shared transport package

## Reconciler direction

The V2 reconciler will be rewritten for the first scene vertical slice. It will batch semantic scene mutations into a supplied sink and will not own RPC, transport, capabilities, or client rendering.

## Validation

- `pnpm run build`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run fmt:check`

Lint completes with the existing V1 warnings and no errors.